### PR TITLE
Improve performance of BDS test when OpenMP is enabled

### DIFF
--- a/src/statistical/test_bds.cpp
+++ b/src/statistical/test_bds.cpp
@@ -79,6 +79,9 @@ double TestBDS<T_INPUT, T_TIME>::embedding_dimension_1(unsigned long m, double e
 
     double sum = 0;
 
+#if defined(_OPENMP)
+    #pragma omp parallel for reduction(+:sum) firstprivate(measures_save, epsilon)
+#endif
     for (unsigned long s = 1; s <= size; s++) {
         T_TIME value_b = std::next(measures_save->cbegin(), s - 1)->second;
         for (unsigned long t = s+1; t <= size; t++) {

--- a/src/statistical/test_bds.cpp
+++ b/src/statistical/test_bds.cpp
@@ -56,6 +56,9 @@ double TestBDS<T_INPUT, T_TIME>::embedding_dimension(unsigned long m, double eps
 
     double sum = 0;
 
+#if defined(_OPENMP)
+    #pragma omp parallel for reduction(+:sum) firstprivate(epsilon)
+#endif
     for (unsigned long s = 1; s <= size; s++) {
         for (unsigned long t = s+1; t <= size; t++) {
             sum += indicator_function(s, t, m, epsilon);


### PR DESCRIPTION
This PR improves performance of the BDS test by parallelizing a couple of functions of quadratic complexity that execute plain reductions without any intra-loop dependencies.